### PR TITLE
เพิ่มกราฟสถิติการบันทึกเวลาบนแดชบอร์ด

### DIFF
--- a/config.py
+++ b/config.py
@@ -3,7 +3,7 @@ import os
 class Config:
     """การตั้งค่าสำหรับแอปพลิเคชัน"""
 
-    VERSION = "0.49.0"
+    VERSION = "0.50.0"
 
     # รหัสสถานะการมาทำงาน
     WORK_STATUS = {

--- a/routes/dashboard.py
+++ b/routes/dashboard.py
@@ -1,6 +1,7 @@
 from flask import render_template, redirect, url_for
 from . import bp
 from .utils import get_connection, sso_authenticated
+from datetime import date, timedelta
 
 @bp.route('/')
 def index():
@@ -27,8 +28,24 @@ def index():
 
             cur.execute('SELECT COUNT(*) AS c FROM behaviors')
             behavior_count = cur.fetchone()['c']
+
+            cur.execute(
+                """
+                SELECT DATE(checkin_time) AS d, COUNT(*) AS c
+                FROM attendances
+                WHERE checkin_time >= CURDATE() - INTERVAL 6 DAY
+                GROUP BY d
+                ORDER BY d
+                """
+            )
+            rows = cur.fetchall()
     finally:
         conn.close()
+
+    stats_map = {row['d']: row['c'] for row in rows}
+    last7 = [date.today() - timedelta(days=i) for i in range(6, -1, -1)]
+    attendance_labels = [d.strftime('%d/%m') for d in last7]
+    attendance_data = [stats_map.get(d, 0) for d in last7]
 
     return render_template(
         'dashboard/index.html',
@@ -39,4 +56,6 @@ def index():
         training_count=training_count,
         activity_count=activity_count,
         behavior_count=behavior_count,
+        attendance_labels=attendance_labels,
+        attendance_data=attendance_data,
     )

--- a/templates/dashboard/index.html
+++ b/templates/dashboard/index.html
@@ -48,4 +48,36 @@
     </div>
   </a>
 </div>
+<div class="mt-8 bg-white p-6 border border-slate-200 rounded-lg shadow-sm">
+  <h2 class="text-xl font-semibold text-slate-700 mb-4 flex items-center gap-2">
+    <i class="fa-solid fa-chart-column text-blue-600"></i>
+    สถิติการบันทึกเวลา 7 วันล่าสุด
+  </h2>
+  <canvas id="attendanceChart" height="120"></canvas>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script>
+  const ctx = document.getElementById('attendanceChart').getContext('2d');
+  new Chart(ctx, {
+    type: 'bar',
+    data: {
+      labels: {{ attendance_labels|tojson }},
+      datasets: [{
+        label: 'จำนวนการบันทึกเวลา',
+        data: {{ attendance_data|tojson }},
+        backgroundColor: 'rgba(37, 99, 235, 0.5)',
+        borderColor: 'rgba(37, 99, 235, 1)',
+        borderWidth: 1
+      }]
+    },
+    options: {
+      scales: {
+        y: { beginAtZero: true, ticks: { stepSize: 1 } }
+      }
+    }
+  });
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- แสดงแผนภูมิสรุปการบันทึกเวลา 7 วันล่าสุดบนแดชบอร์ดด้วย Chart.js
- ปรับ route ของแดชบอร์ดให้ดึงข้อมูลการบันทึกเวลาและส่งไปยังเทมเพลต
- เพิ่มหมายเลขเวอร์ชันแอปเป็น 0.50.0

## Testing
- `python -m py_compile $(git ls-files '*.py') && echo 'py_compile passed'`


------
https://chatgpt.com/codex/tasks/task_e_6892cbfb0244832a9be80b1841c613e0